### PR TITLE
fix: flatten schema names for dev and CI targets

### DIFF
--- a/dbt/macros/generate_schema_name.sql
+++ b/dbt/macros/generate_schema_name.sql
@@ -1,7 +1,5 @@
 {% macro generate_schema_name(custom_schema_name, node) %}
-    {%- if target.name == 'staging' -%}
-        {{ target.schema }}
-    {%- elif custom_schema_name is not none -%}
+    {%- if target.name == 'prod' and custom_schema_name is not none -%}
         {{ custom_schema_name }}
     {%- else -%}
         {{ target.schema }}


### PR DESCRIPTION
## Summary
- Only use custom schema names (SOURCE, INTERMEDIATE, MARTS) when `target.name == 'prod'`
- Dev target now writes all models to the user's dev schema (e.g., DEV_MARK)
- Staging/CI target writes all models flat to STAGING

## Test plan
- [ ] Run `dbt run --profiles-dir ./ --target dev` — all models should go to DEV_* schema
- [ ] CD pipeline still writes to SOURCE/INTERMEDIATE/MARTS on prod target

🤖 Generated with [Claude Code](https://claude.com/claude-code)