### PR TITLE
feat: add dim_seat dimension and integrate into fct_review

### DIFF
--- a/dbt/models/marts/dim_seat.sql
+++ b/dbt/models/marts/dim_seat.sql
@@ -1,0 +1,39 @@
+{{ config(
+    materialized='table',
+) }}
+
+-- dim_seat.sql
+-- Seat dimension table
+-- Grain: one row per unique (seat_type, type_of_traveller) combination
+-- Surrogate key: generated using dbt_utils for deterministic, idempotent key generation
+
+with reviews as (
+
+    select
+        *,
+    from {{ ref('int_reviews_cleaned') }}
+
+),
+
+distinct_seats as (
+
+    select distinct
+        coalesce(seat_type, 'unknown') as seat_type,
+        coalesce(type_of_traveller, 'unknown') as type_of_traveller,
+    from reviews
+
+),
+
+final as (
+
+    select
+        {{ dbt_utils.generate_surrogate_key(['seat_type', 'type_of_traveller']) }} as seat_id,
+        seat_type,
+        type_of_traveller,
+    from distinct_seats
+
+)
+
+select
+    *,
+from final

--- a/dbt/models/marts/fct_review.sql
+++ b/dbt/models/marts/fct_review.sql
@@ -84,6 +84,18 @@ with_aircraft as (
 
 ),
 
+with_seat as (
+
+    select
+        wa.*,
+        ds.seat_id,
+    from with_aircraft as wa
+    left join {{ ref('dim_seat') }} as ds
+        on coalesce(wa.seat_type, 'unknown') = ds.seat_type
+        and coalesce(wa.type_of_traveller, 'unknown') = ds.type_of_traveller
+
+),
+
 with_ratings as (
 
     select
@@ -111,7 +123,7 @@ with_ratings as (
             ),
             2
         ) as average_rating,
-    from with_aircraft as wa
+    from with_seat as wa
 
 ),
 
@@ -127,10 +139,9 @@ final as (
         destination_location_id,
         transit_location_id,
         aircraft_id,
+        seat_id,
         review_id,
         is_verified,
-        seat_type,
-        type_of_traveller,
         seat_comfort,
         cabin_staff_service,
         food_and_beverages,
@@ -159,6 +170,7 @@ final as (
         and destination_location_id is not null
         and transit_location_id is not null
         and aircraft_id is not null
+        and seat_id is not null
         -- Remove rows with invalid rating values (must be between 1-5, or allow null)
         and (seat_comfort is null or (seat_comfort >= 1 and seat_comfort <= 5))
         and (cabin_staff_service is null or (cabin_staff_service >= 1 and cabin_staff_service <= 5))

--- a/dbt/models/marts/marts_schema.yml
+++ b/dbt/models/marts/marts_schema.yml
@@ -120,6 +120,18 @@ models:
           meta:
             datatypes: string
 
+      - name: seat_id
+        description: Foreign key to dim_seat.
+        tests:
+          - not_null
+          - relationships:
+              arguments:
+                to: ref('dim_seat')
+                field: seat_id
+        config:
+          meta:
+            datatypes: string
+
       - name: is_verified
         description: Whether the review was verified by the airline.
         tests:
@@ -129,26 +141,6 @@ models:
         config:
           meta:
             datatypes: boolean
-
-      - name: seat_type
-        description: Type of seat purchased (Premium Economy, Business Class, Economy Class, First Class).
-        tests:
-          - accepted_values:
-              arguments:
-                values: ['Premium Economy', 'Business Class', 'Economy Class', 'First Class', null]
-        config:
-          meta:
-            datatypes: string
-
-      - name: type_of_traveller
-        description: Category of traveller (Business, Couple Leisure, Family Leisure, Solo Leisure).
-        tests:
-          - accepted_values:
-              arguments:
-                values: ['Business', 'Couple Leisure', 'Family Leisure', 'Solo Leisure', null]
-        config:
-          meta:
-            datatypes: string
 
       - name: seat_comfort
         description: Seat comfort rating (1-5 scale, null allowed).
@@ -543,6 +535,43 @@ models:
         config:
           meta:
             datatypes: integer
+
+    config:
+      meta:
+        contracts:
+          enabled: true
+
+# ---
+
+  - name: dim_seat
+    description: |
+      Seat dimension table combining seat class and traveller type.
+      Grain: one row per unique (seat_type, type_of_traveller) combination.
+    columns:
+      - name: seat_id
+        description: Surrogate key for seat (deterministic, idempotent).
+        tests:
+          - unique
+          - not_null
+        config:
+          meta:
+            datatypes: string
+
+      - name: seat_type
+        description: Type of seat purchased (Premium Economy, Business Class, Economy Class, First Class, unknown).
+        tests:
+          - not_null
+        config:
+          meta:
+            datatypes: string
+
+      - name: type_of_traveller
+        description: Category of traveller (Business, Couple Leisure, Family Leisure, Solo Leisure, unknown).
+        tests:
+          - not_null
+        config:
+          meta:
+            datatypes: string
 
     config:
       meta:


### PR DESCRIPTION
## Summary
- Add `dim_seat` dimension table with grain: one row per unique (seat_type, type_of_traveller)
- Replace raw `seat_type` and `type_of_traveller` columns in `fct_review` with `seat_id` foreign key
- Add schema tests (unique, not_null, relationships) for the new dimension

## Test plan
- [ ] CI detects `dim_seat` as new model and `fct_review` as modified
- [ ] `dbt clone` copies prod tables to staging
- [ ] Changed models build successfully (dim_seat, fct_review)
- [ ] Downstream tests pass (relationship tests between fct_review and dim_seat)

🤖 Generated with [Claude Code](https://claude.com/claude-code)