### PR TITLE
feat: add has_layover boolean to fct_review

### DIFF
--- a/dbt/models/marts/fct_review.sql
+++ b/dbt/models/marts/fct_review.sql
@@ -139,6 +139,7 @@ final as (
         wifi_and_connectivity,
         value_for_money,
         recommended,
+        transit_city != 'unknown' as has_layover,
         average_rating,
         case
             when average_rating is null then 'unknown'

--- a/dbt/models/marts/marts_schema.yml
+++ b/dbt/models/marts/marts_schema.yml
@@ -150,6 +150,17 @@ models:
           meta:
             datatypes: string
 
+      - name: has_layover
+        description: Whether the flight included a transit stop.
+        tests:
+          - not_null
+          - accepted_values:
+              arguments:
+                values: [true, false]
+        config:
+          meta:
+            datatypes: boolean
+
       - name: seat_comfort
         description: Seat comfort rating (1-5 scale, null allowed).
         tests:


### PR DESCRIPTION
## Summary
- Add `has_layover` boolean column to `fct_review` derived from whether transit_city is populated
- Enables filtering and analysis of review sentiment by direct vs. connecting flights

## Test plan
- [ ] CI detects `fct_review` as modified
- [ ] `dbt clone` copies prod tables to staging
- [ ] `fct_review` builds successfully with the new column
- [ ] All existing and new tests pass (not_null, accepted_values for has_layover)

🤖 Generated with [Claude Code](https://claude.com/claude-code)