### PR TITLE
refactor: rename project to skytrax_transformation

### DIFF
--- a/dbt-dags/dags/transformation_dag.py
+++ b/dbt-dags/dags/transformation_dag.py
@@ -14,7 +14,7 @@ default_args = {
 }
 
 profile_config = ProfileConfig(
-    profile_name="ba_transformation",
+    profile_name="skytrax_transformation",
     target_name="prod",
     profile_mapping=SnowflakeUserPasswordProfileMapping(
         conn_id="snowflake_default",

--- a/dbt/dbt_project.yml
+++ b/dbt/dbt_project.yml
@@ -1,11 +1,11 @@
 # Name your project! Project names should contain only lowercase characters
 # and underscores. A good package name should reflect your organization's
 # name or the intended use of these models
-name: 'ba_transformation'
+name: 'skytrax_transformation'
 version: '1.0.0'
 
 # This setting configures which "profile" dbt uses for this project.
-profile: 'ba_transformation'
+profile: 'skytrax_transformation'
 
 # These configurations specify where dbt should look for different types of files.
 # The `model-paths` config, for example, states that models in this project can be
@@ -29,7 +29,7 @@ clean-targets:
 # directory as views. These settings can be overridden in the individual model
 # files using the `{{ config(...) }}` macro.
 models:
-  ba_transformation:
+  skytrax_transformation:
     # Config indicated by + and applies to all files under models/example/
     staging:
       +materialized: view
@@ -48,7 +48,7 @@ models:
       +tags: ['marts']
 
 seeds:
-  ba_transformation:
+  skytrax_transformation:
     review:
       +enabled: true
       +tags: ['seeds']

--- a/dbt/profiles.yml
+++ b/dbt/profiles.yml
@@ -1,4 +1,4 @@
-ba_transformation:
+skytrax_transformation:
   target: dev
   outputs:
     dev:


### PR DESCRIPTION
## Summary
- Rename dbt project from `ba_transformation` to `skytrax_transformation` across all config files
- Updated `dbt/dbt_project.yml` (name, profile, models, seeds)
- Updated `dbt/profiles.yml` (profile key)
- Updated `dbt-dags/dags/transformation_dag.py` (cosmos profile_name)

## Test plan
- [ ] CI pipeline passes (dbt compile, run, test use the new project name)
- [ ] Verify `dbt debug --profiles-dir ./` connects successfully with new profile name

🤖 Generated with [Claude Code](https://claude.com/claude-code)