### PR TITLE
docs: redact Snowflake account locator from public docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -205,7 +205,7 @@ How we host dbt docs with CloudFront + S3 (and why we switched from EC2).
 pip install -r requirements-dev.txt
 
 # Set Snowflake env vars
-export SNOWFLAKE_ACCOUNT=nvnjoib-on80344
+export SNOWFLAKE_ACCOUNT=<your-account-locator>
 export SNOWFLAKE_USER=your_user
 export SNOWFLAKE_PASSWORD=your_password
 export SNOWFLAKE_ROLE=SKYTRAX_ANALYST
@@ -259,7 +259,7 @@ setup.cfg                   SQLFluff config
 
 | Secret | Description |
 | -------- | ------------- |
-| `SNOWFLAKE_ACCOUNT` | `nvnjoib-on80344` |
+| `SNOWFLAKE_ACCOUNT` | `<your-account-locator>` |
 | `SNOWFLAKE_USER` | `DBT_CICD` |
 | `SNOWFLAKE_PASSWORD` | Password for DBT_CICD user |
 | `SNOWFLAKE_ROLE` | `SKYTRAX_TRANSFORMER` |

--- a/docs/ARTICLE.md
+++ b/docs/ARTICLE.md
@@ -230,7 +230,7 @@ Now the Snowflake infrastructure is ready. Let's connect dbt to it and run our m
 Set these based on your Snowflake user. Each developer gets their own dev schema:
 
 ```bash
-export SNOWFLAKE_ACCOUNT=nvnjoib-on80344
+export SNOWFLAKE_ACCOUNT=<your-account-locator>
 export SNOWFLAKE_USER=your_user
 export SNOWFLAKE_PASSWORD=your_password
 export SNOWFLAKE_ROLE=SKYTRAX_ANALYST
@@ -441,7 +441,7 @@ Go to your GitHub repo → Settings → Secrets and variables → Actions. Add t
 
 | Secret | Value | Where to get it |
 | ------ | ----- | --------------- |
-| `SNOWFLAKE_ACCOUNT` | `nvnjoib-on80344` | Your Snowflake account identifier |
+| `SNOWFLAKE_ACCOUNT` | `<your-account-locator>` | Your Snowflake account identifier |
 | `SNOWFLAKE_USER` | `DBT_CICD` | The CI/CD service account from Step 2 |
 | `SNOWFLAKE_PASSWORD` | (password you set) | From `terraform.tfvars` |
 | `SNOWFLAKE_ROLE` | `SKYTRAX_TRANSFORMER` | The role with prod schema access |

--- a/docs/cicd.md
+++ b/docs/cicd.md
@@ -305,7 +305,7 @@ GitHub Actions assumes it via OIDC.
 
 | Secret | Description | Example |
 | ------ | ----------- | ------- |
-| `SNOWFLAKE_ACCOUNT` | Snowflake account identifier | `nvnjoib-on80344` |
+| `SNOWFLAKE_ACCOUNT` | Snowflake account identifier | `<your-account-locator>` |
 | `SNOWFLAKE_USER` | CI/CD service account | `DBT_CICD` |
 | `SNOWFLAKE_PASSWORD` | Password for DBT_CICD | — |
 | `SNOWFLAKE_ROLE` | Role for CI/CD | `SKYTRAX_TRANSFORMER` |

--- a/docs/local-development.md
+++ b/docs/local-development.md
@@ -21,7 +21,7 @@ pip install -r requirements-dev.txt  # includes dbt + dev tools (pandas, ipykern
 Set these based on your Snowflake user. Each developer has their own dev schema (`SNOWFLAKE_SCHEMA`).
 
 ```bash
-export SNOWFLAKE_ACCOUNT=nvnjoib-on80344
+export SNOWFLAKE_ACCOUNT=<your-account-locator>
 export SNOWFLAKE_USER=your_user            # your Snowflake username
 export SNOWFLAKE_PASSWORD=your_password
 export SNOWFLAKE_ROLE=SKYTRAX_ANALYST


### PR DESCRIPTION
## Summary
- Replace hard-coded Snowflake account locator with `<your-account-locator>` in README and docs.
- Does **not** change S3/CloudFront public `manifests/*` access (kept public for local defer via curl).

## Test plan
- [ ] Grep repo for old locator → zero hits in docs
- [ ] Local defer docs still show public curl for manifests

Made with [Cursor](https://cursor.com)