### PR TITLE
feat: optional key-pair auth scaffolding for service accounts

### DIFF
--- a/dbt/profiles.yml
+++ b/dbt/profiles.yml
@@ -18,6 +18,11 @@ skytrax_transformation:
       account: "{{ env_var('SNOWFLAKE_ACCOUNT') }}"
       user: "{{ env_var('SNOWFLAKE_USER') }}"
       password: "{{ env_var('SNOWFLAKE_PASSWORD') }}"
+      # Key-pair auth (planned cutover -- see docs/keypair-auth.md):
+      # replace `password:` with the two lines below once the PROD_DBT
+      # public key is provisioned via Terraform.
+      # private_key_path: "{{ env_var('SNOWFLAKE_PRIVATE_KEY_PATH') }}"
+      # private_key_passphrase: "{{ env_var('SNOWFLAKE_PRIVATE_KEY_PASSPHRASE', '') }}"
       role: "{{ env_var('SNOWFLAKE_ROLE') }}"
       database: SKYTRAX_REVIEWS_DB
       schema: SOURCE
@@ -31,6 +36,11 @@ skytrax_transformation:
       account: "{{ env_var('SNOWFLAKE_ACCOUNT') }}"
       user: "{{ env_var('SNOWFLAKE_USER') }}"
       password: "{{ env_var('SNOWFLAKE_PASSWORD') }}"
+      # Key-pair auth (planned cutover -- see docs/keypair-auth.md):
+      # replace `password:` with the two lines below once the DBT_CICD
+      # public key is provisioned via Terraform.
+      # private_key_path: "{{ env_var('SNOWFLAKE_PRIVATE_KEY_PATH') }}"
+      # private_key_passphrase: "{{ env_var('SNOWFLAKE_PRIVATE_KEY_PASSPHRASE', '') }}"
       role: "{{ env_var('SNOWFLAKE_ROLE') }}"
       database: SKYTRAX_REVIEWS_DB
       schema: STAGING

--- a/docs/keypair-auth.md
+++ b/docs/keypair-auth.md
@@ -1,0 +1,93 @@
+# Key-Pair Auth for Service Accounts
+
+Snowflake recommends RSA key-pair auth over passwords for service accounts
+(`DBT_CICD`, `PROD_DBT`): no shared secret to rotate through GitHub, and keys
+can be rotated one at a time via `RSA_PUBLIC_KEY` / `RSA_PUBLIC_KEY_2`.
+
+The Terraform and dbt scaffolding for this is already in place but **inactive**:
+
+- `terraform/snowflake/users.tf` -- both service users accept an optional
+  `rsa_public_key` (null by default, so nothing changes until you set it)
+- `dbt/profiles.yml` -- commented `private_key_path` lines on the `prod` and
+  `staging` targets
+
+Password auth keeps working the whole time; Snowflake allows both credentials
+on one user, so this is a zero-downtime cutover.
+
+## 1. Generate a key pair (one per service account)
+
+```bash
+# Private key (PKCS#8, encrypted -- you'll be prompted for a passphrase)
+openssl genrsa 2048 | openssl pkcs8 -topk8 -v2 aes-256-cbc -inform PEM -out dbt_cicd_rsa_key.p8
+
+# Public key
+openssl rsa -in dbt_cicd_rsa_key.p8 -pubout -out dbt_cicd_rsa_key.pub
+```
+
+Repeat with `prod_dbt_` filenames for `PROD_DBT`. Keep the `.p8` files out of
+git (store them in a password manager / secret store).
+
+## 2. Attach the public key via Terraform
+
+Snowflake wants the PEM *body only* (no `-----BEGIN/END PUBLIC KEY-----`
+lines, no newlines):
+
+```bash
+grep -v "PUBLIC KEY" dbt_cicd_rsa_key.pub | tr -d '\n'
+```
+
+Set the value as a Terraform variable (tfvars or environment):
+
+```bash
+export TF_VAR_cicd_rsa_public_key='MIIBIjANBgkqh...'
+export TF_VAR_prod_dbt_rsa_public_key='MIIBIjANBgkqh...'
+
+cd terraform/snowflake
+terraform plan   # expect: update in-place on the two snowflake_user resources
+terraform apply
+```
+
+## 3. Wire the private key into each consumer
+
+### GitHub Actions (DBT_CICD)
+
+1. Add repo secrets:
+   - `SNOWFLAKE_PRIVATE_KEY` -- full contents of `dbt_cicd_rsa_key.p8`
+   - `SNOWFLAKE_PRIVATE_KEY_PASSPHRASE` -- the passphrase from step 1
+2. In the workflows, materialize the key to a file and export the env vars the
+   profile reads:
+
+   ```yaml
+   - name: Write Snowflake private key
+     run: |
+       echo "${{ secrets.SNOWFLAKE_PRIVATE_KEY }}" > $RUNNER_TEMP/snowflake_key.p8
+       echo "SNOWFLAKE_PRIVATE_KEY_PATH=$RUNNER_TEMP/snowflake_key.p8" >> "$GITHUB_ENV"
+       echo "SNOWFLAKE_PRIVATE_KEY_PASSPHRASE=${{ secrets.SNOWFLAKE_PRIVATE_KEY_PASSPHRASE }}" >> "$GITHUB_ENV"
+   ```
+
+### Airflow (PROD_DBT)
+
+Mount `prod_dbt_rsa_key.p8` into the container and set
+`SNOWFLAKE_PRIVATE_KEY_PATH` / `SNOWFLAKE_PRIVATE_KEY_PASSPHRASE` in
+`dbt-dags/.env` (cosmos passes profile env through to dbt).
+
+## 4. Flip the profile
+
+In `dbt/profiles.yml`, on the `prod` and `staging` targets: delete the
+`password:` line and uncomment the two `private_key_*` lines. Verify with:
+
+```bash
+dbt debug --profiles-dir ./ --target prod
+```
+
+## 5. Retire the passwords (later, deliberate step)
+
+Once both consumers authenticate with keys for a full cycle (one deploy, one
+scheduled run, one PR check), remove `password = var.*_password` from the two
+users in `users.tf`, apply, and delete the `SNOWFLAKE_PASSWORD` GitHub secret.
+
+## Rotation
+
+Set the new key as `RSA_PUBLIC_KEY_2` (add a second variable/attribute),
+switch consumers to the new private key, then clear the old `RSA_PUBLIC_KEY`.
+Never an outage, never a shared-secret handoff.

--- a/terraform/snowflake/users.tf
+++ b/terraform/snowflake/users.tf
@@ -3,9 +3,12 @@
 # -----------------------------------------------------------------------------
 
 resource "snowflake_user" "prod_dbt" {
-  name              = "PROD_DBT"
-  login_name        = "PROD_DBT"
-  password          = var.prod_dbt_password
+  name       = "PROD_DBT"
+  login_name = "PROD_DBT"
+  password   = var.prod_dbt_password
+  # Optional key-pair auth (see docs/keypair-auth.md). Null until the key is
+  # provisioned; password auth continues to work alongside it.
+  rsa_public_key    = var.prod_dbt_rsa_public_key
   default_warehouse = snowflake_warehouse.compute["XSMALL"].name
   default_role      = snowflake_account_role.transformer.name
   default_namespace = "${var.database_name}.STAGING"
@@ -13,9 +16,12 @@ resource "snowflake_user" "prod_dbt" {
 }
 
 resource "snowflake_user" "cicd" {
-  name              = "DBT_CICD"
-  login_name        = "DBT_CICD"
-  password          = var.cicd_user_password
+  name       = "DBT_CICD"
+  login_name = "DBT_CICD"
+  password   = var.cicd_user_password
+  # Optional key-pair auth (see docs/keypair-auth.md). Null until the key is
+  # provisioned; password auth continues to work alongside it.
+  rsa_public_key    = var.cicd_rsa_public_key
   default_warehouse = snowflake_warehouse.compute["XSMALL"].name
   default_role      = snowflake_account_role.transformer.name
   default_namespace = "${var.database_name}.STAGING"

--- a/terraform/snowflake/variables.tf
+++ b/terraform/snowflake/variables.tf
@@ -59,6 +59,24 @@ variable "cicd_user_password" {
   sensitive   = true
 }
 
+# --- Service Account Key-Pair Auth (optional, additive) ---
+# When set, the RSA public key is attached to the service user so it can also
+# authenticate with a private key. Password auth keeps working until the
+# password is removed in a separate, deliberate step.
+# See docs/keypair-auth.md for the full rollout procedure.
+
+variable "prod_dbt_rsa_public_key" {
+  description = "RSA public key for PROD_DBT key-pair auth (PEM body without header/footer). Null = password auth only."
+  type        = string
+  default     = null
+}
+
+variable "cicd_rsa_public_key" {
+  description = "RSA public key for DBT_CICD key-pair auth (PEM body without header/footer). Null = password auth only."
+  type        = string
+  default     = null
+}
+
 variable "gina_analyst_password" {
   description = "Password for GINA_ANALYST user"
   type        = string


### PR DESCRIPTION
## Summary
- Add Terraform `rsa_public_key` variables for `DBT_CICD` / `PROD_DBT`.
- Document key-pair setup; keep password auth working until keys are set.

## Test plan
- [ ] `terraform plan` in `terraform/snowflake` with empty key vars (no-op)
- [ ] Docs in `docs/keypair-auth.md` match variables

Made with [Cursor](https://cursor.com)