### PR TITLE
feat: add Snowflake resource monitor and statement timeouts

### DIFF
--- a/terraform/snowflake/variables.tf
+++ b/terraform/snowflake/variables.tf
@@ -45,6 +45,12 @@ variable "warehouse_auto_suspend" {
   default     = 60
 }
 
+variable "monthly_credit_quota" {
+  description = "Monthly credit cap enforced by the shared resource monitor across all project warehouses"
+  type        = number
+  default     = 10
+}
+
 # --- User Passwords ---
 
 variable "prod_dbt_password" {

--- a/terraform/snowflake/warehouses.tf
+++ b/terraform/snowflake/warehouses.tf
@@ -3,7 +3,35 @@
 # -----------------------------------------------------------------------------
 # A dedicated set of warehouses for this project. Auto-suspend keeps costs low
 # when nobody is running queries. Creating 5 warehouses of increasing size.
+# Every warehouse is wired to a shared monthly resource monitor (cost cap) and
+# gets a per-size statement timeout: short where humans/CI iterate (XSMALL
+# dev, SMALL CI) so runaway queries die fast, longer where full production
+# builds run (MEDIUM prod, LARGE/XLARGE ad-hoc backfills).
 # -----------------------------------------------------------------------------
+
+locals {
+  # statement_timeout_in_seconds per warehouse size
+  warehouse_statement_timeouts = {
+    XSMALL = 600  # local dev -- fail fast
+    SMALL  = 900  # CI PR checks -- a hung query should not eat the quota
+    MEDIUM = 3600 # prod deploys + Airflow full builds
+    LARGE  = 3600 # ad-hoc heavy queries / backfills
+    XLARGE = 3600 # ad-hoc heavy queries / backfills
+  }
+}
+
+# Monthly credit cap across ALL project warehouses. Notifies at 50/75/90%,
+# suspends new queries at 100%, and kills running queries at 110%.
+resource "snowflake_resource_monitor" "skytrax_monthly" {
+  name            = "SKYTRAX_MONTHLY_MONITOR"
+  credit_quota    = var.monthly_credit_quota
+  frequency       = "MONTHLY"
+  start_timestamp = "IMMEDIATELY"
+
+  notify_triggers           = [50, 75, 90]
+  suspend_trigger           = 100
+  suspend_immediate_trigger = 110
+}
 
 resource "snowflake_warehouse" "compute" {
   for_each       = toset(local.warehouse_sizes)
@@ -14,6 +42,9 @@ resource "snowflake_warehouse" "compute" {
 
   min_cluster_count = 1
   max_cluster_count = 1
+
+  resource_monitor             = snowflake_resource_monitor.skytrax_monthly.fully_qualified_name
+  statement_timeout_in_seconds = local.warehouse_statement_timeouts[each.value]
 
   comment = "Skytrax ${each.value} warehouse. Managed by Terraform."
 }


### PR DESCRIPTION
## Summary
- Add `snowflake_resource_monitor` credit cap and per-warehouse statement timeouts in Terraform.

## Test plan
- [ ] `terraform plan` shows monitor + warehouse timeout updates