### PR TITLE
feat: tag local, CI, and Airflow cosmos queries for cost attribution

### DIFF
--- a/dbt-dags/dags/transformation_dag.py
+++ b/dbt-dags/dags/transformation_dag.py
@@ -22,7 +22,10 @@ profile_config = ProfileConfig(
             "database": "SKYTRAX_REVIEWS_DB",
             "schema": "SOURCE",
             "warehouse": "SKYTRAX_COMPUTE_MEDIUM",
-            "role": "SKYTRAX_TRANSFORMER"
+            "role": "SKYTRAX_TRANSFORMER",
+            # Tag every Airflow-issued query so warehouse usage is attributable
+            # in QUERY_HISTORY (vs github_action_deploy / github_action_ci / local_dev)
+            "query_tag": "airflow_cosmos"
         }
     )
 )

--- a/dbt/profiles.yml
+++ b/dbt/profiles.yml
@@ -12,6 +12,7 @@ skytrax_transformation:
       threads: 10
       warehouse: SKYTRAX_COMPUTE_XSMALL
       client_session_keep_alive: False
+      query_tag: local_dev
 
     prod:
       type: snowflake


### PR DESCRIPTION
## Summary
- Set `query_tag` in dbt profiles (local/CI/deploy) and cosmos Airflow profile mapping.

## Test plan
- [ ] `profiles.yml` tags present for targets
- [ ] cosmos DAG profile_args includes `query_tag: airflow_cosmos`