### PR TITLE
feat: manage SNAPSHOTS schema in Terraform

### DIFF
--- a/terraform/snowflake/databases.tf
+++ b/terraform/snowflake/databases.tf
@@ -45,6 +45,15 @@ resource "snowflake_schema" "marts" {
   comment  = "Mart models -- business-ready tables for BI tools"
 }
 
+# Creating the snapshots schema (dbt snapshots: snapshots/snap_skytrax_reviews.sql
+# targets schema='SNAPSHOTS'; managed here so grants don't depend on dbt
+# implicitly creating it)
+resource "snowflake_schema" "snapshots" {
+  database = var.database_name
+  name     = "SNAPSHOTS"
+  comment  = "SCD2 history captured by dbt snapshot"
+}
+
 # Creating the dev_minh schema
 resource "snowflake_schema" "dev_minh" {
   database = var.database_name

--- a/terraform/snowflake/main.tf
+++ b/terraform/snowflake/main.tf
@@ -18,6 +18,7 @@ locals {
     intermediate = snowflake_schema.intermediate.name
     staging      = snowflake_schema.staging.name
     marts        = snowflake_schema.marts.name
+    snapshots    = snowflake_schema.snapshots.name
   }
 
   # Per-user dev schemas


### PR DESCRIPTION
## Summary
- Create SNAPSHOTS schema in Terraform and grant transformer access.

## Test plan
- [ ] `terraform plan` shows schema + grants