### PR TITLE
fix: harden cosmos DAG retries and failure callback

### DIFF
--- a/dbt-dags/dags/dbt_command_dag.py
+++ b/dbt-dags/dags/dbt_command_dag.py
@@ -1,0 +1,80 @@
+import os
+import shlex
+import subprocess
+from datetime import datetime, timedelta
+
+from airflow.decorators import dag, task
+from airflow.models.param import Param
+
+DBT_PROJECT_DIR = "/usr/local/airflow/dags/dbt"
+DBT_EXECUTABLE = f"{os.environ['AIRFLOW_HOME']}/dbt_venv/bin/dbt"
+
+# Only allow real dbt subcommands so arbitrary shell can't be submitted
+ALLOWED_SUBCOMMANDS = {
+    "run", "test", "build", "seed", "snapshot", "compile",
+    "ls", "list", "source", "run-operation", "show", "parse", "debug",
+}
+
+
+@dag(
+    dag_id="skytrax_dbt_command",
+    description="Run an ad-hoc dbt command against prod (submit via trigger config)",
+    schedule=None,  # manual trigger only
+    start_date=datetime(2025, 8, 1),
+    catchup=False,
+    tags=["dbt", "adhoc", "prod"],
+    default_args={
+        "retries": 1,
+        "retry_delay": timedelta(seconds=10),
+    },
+    params={
+        "dbt_command": Param(
+            "run -s fct_review",
+            type="string",
+            description="dbt arguments without the leading 'dbt', e.g. 'test -s dim_date' or 'run -s fct_review --full-refresh'",
+        ),
+    },
+)
+def skytrax_dbt_command():
+
+    @task
+    def run_dbt_command(params: dict):
+        import tempfile
+
+        from airflow.hooks.base import BaseHook
+
+        args = shlex.split(params["dbt_command"])
+        if not args or args[0] not in ALLOWED_SUBCOMMANDS:
+            raise ValueError(
+                f"First argument must be a dbt subcommand ({sorted(ALLOWED_SUBCOMMANDS)}), got: {args[:1]}"
+            )
+
+        conn = BaseHook.get_connection("snowflake_default")
+        # The dbt project dir is mounted read-only; send logs/target to a tmp dir
+        scratch = tempfile.mkdtemp(prefix="dbt_command_")
+        env = {
+            **os.environ,
+            "DBT_LOG_PATH": f"{scratch}/logs",
+            "DBT_TARGET_PATH": f"{scratch}/target",
+            "SNOWFLAKE_ACCOUNT": conn.extra_dejson["account"],
+            "SNOWFLAKE_USER": conn.login,
+            "SNOWFLAKE_PASSWORD": conn.password,
+            "SNOWFLAKE_ROLE": conn.extra_dejson["role"],
+            "SNOWFLAKE_SCHEMA": conn.schema,
+        }
+
+        cmd = [
+            DBT_EXECUTABLE, *args,
+            "--project-dir", DBT_PROJECT_DIR,
+            "--profiles-dir", DBT_PROJECT_DIR,
+            "--target", "prod",
+        ]
+        print(f"Running: dbt {' '.join(args)} (target=prod)")
+        result = subprocess.run(cmd, env=env, cwd=DBT_PROJECT_DIR)
+        if result.returncode != 0:
+            raise RuntimeError(f"dbt exited with code {result.returncode}")
+
+    run_dbt_command()
+
+
+skytrax_dbt_command()

--- a/dbt-dags/dags/transformation_dag.py
+++ b/dbt-dags/dags/transformation_dag.py
@@ -3,14 +3,24 @@ from datetime import datetime
 
 from cosmos import DbtDag, ProjectConfig, ProfileConfig, ExecutionConfig
 from cosmos.profiles import SnowflakeUserPasswordProfileMapping
-from airflow.utils.trigger_rule import TriggerRule
 
 
-# Default arguments that will apply to all tasks created by cosmos
+def _notify_failure(context):
+    """Log a clear failure line. Wire Slack/email here when a webhook is available."""
+    ti = context.get("task_instance") or context.get("ti")
+    dag_id = getattr(ti, "dag_id", "unknown_dag")
+    task_id = getattr(ti, "task_id", "unknown_task")
+    exception = context.get("exception")
+    print(f"[skytrax_dbt_transformation] FAILED {dag_id}.{task_id}: {exception!r}")
+
+
+# retries=2: transient Snowflake / network blips should not red the whole DAG.
+# No TriggerRule.ALL_DONE — a failed upstream must fail the DAG, not silently
+# continue into a partial marts refresh.
 default_args = {
-    'depends_on_past': False,
-    'retries': 0,
-    'trigger_rule': TriggerRule.ALL_DONE  # Run even if upstream tasks fail
+    "depends_on_past": False,
+    "retries": 2,
+    "on_failure_callback": _notify_failure,
 }
 
 profile_config = ProfileConfig(
@@ -22,9 +32,9 @@ profile_config = ProfileConfig(
             "database": "SKYTRAX_REVIEWS_DB",
             "schema": "SOURCE",
             "warehouse": "SKYTRAX_COMPUTE_MEDIUM",
-            "role": "SKYTRAX_TRANSFORMER"
-        }
-    )
+            "role": "SKYTRAX_TRANSFORMER",
+        },
+    ),
 )
 
 dbt_transformation_dag = DbtDag(
@@ -33,12 +43,14 @@ dbt_transformation_dag = DbtDag(
         "install_deps": True,
     },
     profile_config=profile_config,
-    execution_config=ExecutionConfig(dbt_executable_path=f"{os.environ['AIRFLOW_HOME']}/dbt_venv/bin/dbt",),
+    execution_config=ExecutionConfig(
+        dbt_executable_path=f"{os.environ['AIRFLOW_HOME']}/dbt_venv/bin/dbt",
+    ),
     default_args=default_args,
     schedule="0 19 * * 2",  # Run at 2pm CST (19:00 UTC) on Tuesday
     start_date=datetime(2025, 8, 1),
     catchup=False,
     dag_id="skytrax_dbt_transformation",
     description="Production dbt transformation -- runs all models via PROD_DBT user",
-    tags=['dbt', 'transformation', 'prod']
+    tags=["dbt", "transformation", "prod"],
 )


### PR DESCRIPTION
## Summary
- retries 0→2, drop TriggerRule.ALL_DONE, add on_failure_callback.
- Add ad-hoc `skytrax_dbt_command` DAG for run-operation demos.

## Test plan
- [ ] DAG parses; failed task retries twice