### PR TITLE
feat: add warn-severity Spirit fleet plausibility test

### DIFF
--- a/dbt/README.md
+++ b/dbt/README.md
@@ -98,3 +98,11 @@ Verify with `describe table SKYTRAX_REVIEWS_DB.MARTS.FCT_REVIEW;` before
 re-running/re-triggering the deploy — a stale local checkout will silently
 full-refresh using the *old* model code and look like it worked without
 actually fixing anything.
+
+## Data plausibility
+
+`tests/assert_spirit_aircraft_airbus.sql` (severity **warn**) flags Spirit
+Airlines reviews whose joined aircraft manufacturer is not Airbus/Unknown.
+Spirit operates an all-A320-family fleet; free-text aircraft fields can invent
+impossible types — treat warn rows as quarantine candidates, not always a join bug.
+

--- a/dbt/tests/assert_spirit_aircraft_airbus.sql
+++ b/dbt/tests/assert_spirit_aircraft_airbus.sql
@@ -1,0 +1,22 @@
+{{ config(severity='warn') }}
+
+-- Spirit Airlines operates an all-Airbus (A320-family) fleet. Reviewer free-text
+-- aircraft fields can invent impossible types (Boeing 747, Embraer, etc.); this
+-- warn-severity singular test quarantines Spirit + non-Airbus/non-Unknown
+-- manufacturer mappings so they surface in CI without failing the build.
+-- Root cause is usually free-text noise, not a dim join bug — inspect rows
+-- before treating failures as a transform defect.
+
+select
+    f.review_id,
+    f.review_key,
+    a.airline_name,
+    ac.aircraft_model,
+    ac.aircraft_manufacturer,
+from {{ ref('fct_review') }} as f
+inner join {{ ref('dim_airline') }} as a
+    on f.airline_id = a.airline_id
+inner join {{ ref('dim_aircraft') }} as ac
+    on f.aircraft_id = ac.aircraft_id
+where lower(a.airline_name) like '%spirit%'
+    and coalesce(ac.aircraft_manufacturer, 'Unknown') not in ('Airbus', 'Unknown')


### PR DESCRIPTION
## Summary
- Singular warn test: Spirit Airlines ⇒ manufacturer Airbus/Unknown.

## Test plan
- [ ] `dbt test -s assert_spirit_aircraft_airbus`