### PR TITLE
fix: run CD deploys with --full-refresh

### DIFF
--- a/.github/workflows/deploy_main.yml
+++ b/.github/workflows/deploy_main.yml
@@ -9,11 +9,12 @@ name: Deploy Main
 #   3. workflow_dispatch -- manual trigger button in the GitHub Actions UI.
 #
 # The build section below has TWO paths:
-#   - Scheduled runs: source freshness check + snapshot + FULL dbt build.
-#     No state selector -- a state:modified+ selection would be empty when no
-#     code changed, making the weekly refresh a no-op.
-#   - Push/dispatch runs: incremental deploy (state:modified+ against the
-#     production manifest from S3), falling back to a full build when no
+#   - Scheduled runs: source freshness check + snapshot + FULL dbt build
+#     (--full-refresh). No state selector -- a state:modified+ selection
+#     would be empty when no code changed, making the weekly refresh a no-op.
+#   - Push/dispatch runs: slim deploy (state:modified+ against the production
+#     manifest from S3) with --full-refresh so incremental schema/type drifts
+#     are reconciled, falling back to a full --full-refresh build when no
 #     prior manifest exists (first deploy).
 # =============================================================================
 on:
@@ -136,26 +137,28 @@ jobs:
           source ../dbt_venv/bin/activate
           dbt snapshot --profiles-dir ./ --target prod
 
-      # Full build -- every model + test, so the weekly run actually refreshes
-      # incremental models and catches upstream data drift.
+      # Full rebuild -- every model + test with --full-refresh so incremental
+      # tables are recreated (avoids on_schema_change failures / stale types).
       - name: Run dbt build (scheduled full refresh)
         if: github.event_name == 'schedule'
         working-directory: ./dbt
         run: |
           source ../dbt_venv/bin/activate
-          dbt build --profiles-dir ./ --target prod
+          dbt build --profiles-dir ./ --target prod --full-refresh
 
       # -----------------------------------------------------------------------
-      # Run models -- PATH 2: push/dispatch incremental deploy
+      # Run models -- PATH 2: push/dispatch slim deploy (full-refresh selected)
       # -----------------------------------------------------------------------
 
-      # Incremental deploy (production slim CI):
+      # Slim deploy (production):
       #   state:modified+ = changed models + their downstream children
+      #   --full-refresh  = recreate selected incrementals so schema/type drift
+      #                      (e.g. AVERAGE_RATING precision) cannot fail the deploy
       #   --defer          = for any model NOT in the selection, reference the
       #                      production version instead of trying to build it
       #   --favor-state    = if a model exists in both current run and state,
       #                      prefer the state version for upstream references
-      - name: Run dbt build (incremental with defer)
+      - name: Run dbt build (modified+ with full-refresh and defer)
         if: github.event_name != 'schedule' && steps.prod_state.outputs.has_state == 'true'
         working-directory: ./dbt
         run: |
@@ -164,19 +167,19 @@ jobs:
             --profiles-dir ./ \
             --target prod \
             --select state:modified+ \
+            --full-refresh \
             --defer \
             --favor-state \
             --state prod_state
 
       # Full build fallback -- if there's no prior manifest (first deploy),
-      # just build and test everything.
-      - name: Run dbt build (full -- no prior state)
+      # rebuild and test everything from scratch.
+      - name: Run dbt build (full-refresh -- no prior state)
         if: github.event_name != 'schedule' && steps.prod_state.outputs.has_state == 'false'
         working-directory: ./dbt
         run: |
           source ../dbt_venv/bin/activate
-          dbt run --profiles-dir ./ --target prod
-          dbt test --profiles-dir ./ --target prod
+          dbt build --profiles-dir ./ --target prod --full-refresh
 
       # -----------------------------------------------------------------------
       # Generate and upload docs


### PR DESCRIPTION
## Description
Follow-up to the failed [Deploy Main #56](https://github.com/MarkPhamm/skytrax_reviews_transformation/actions/runs/30137089801) after #34. Production `fct_review` failed with `on_schema_change='fail'` because `AVERAGE_RATING` type drifted (`NUMBER(38,2)`). CD now passes `--full-refresh` so selected incrementals are recreated.

## Type of Change
- [x] Bug fix (non-breaking change which fixes an issue)
- [x] Configuration change

## Changes Made
- Push/dispatch slim deploy: add `--full-refresh` to `state:modified+` build
- Scheduled weekly deploy: add `--full-refresh` (was named full refresh but only built all models incrementally)
- No-prior-state fallback: use `dbt build --full-refresh` instead of separate run/test without refresh

## Testing
- [ ] Re-run Deploy Main (workflow_dispatch or merge) and confirm `fct_review` succeeds

## Additional Notes
#34 was already merged, so this is a follow-up PR rather than an update to that one.


Made with [Cursor](https://cursor.com)