### PR TITLE
fix: make MetricFlow semantic layer parse on main

### DIFF
--- a/dbt/models/marts/fct_review_semantic.yml
+++ b/dbt/models/marts/fct_review_semantic.yml
@@ -1,6 +1,8 @@
 # MetricFlow / dbt Semantic Layer (legacy standalone YAML — dbt-core 1.10).
 # Query with `mf query --metrics avg_rating --group-by rating_band` after
 # `dbt parse` (MetricFlow CLI) or via the dbt Semantic Layer.
+#
+# Ratio metrics must reference other *metrics*, not raw measures.
 
 version: 2
 
@@ -37,11 +39,11 @@ semantic_models:
         description: Mean of per-review average_rating.
         agg: average
         expr: average_rating
-      - name: recommended
+      - name: recommended_sum
         description: Count of reviews that recommend the airline.
         agg: sum
         expr: "case when recommended then 1 else 0 end"
-      - name: review_count
+      - name: reviews
         description: Number of reviews.
         agg: count
         expr: review_id
@@ -54,10 +56,24 @@ metrics:
     type_params:
       measure: average_rating
 
+  - name: recommended_count
+    label: Recommended Reviews
+    description: Count of reviews that recommend the airline.
+    type: simple
+    type_params:
+      measure: recommended_sum
+
+  - name: review_count
+    label: Review Count
+    description: Number of reviews.
+    type: simple
+    type_params:
+      measure: reviews
+
   - name: pct_recommended
     label: Percent Recommended
     description: Share of reviews that recommend the airline (recommended / review_count).
     type: ratio
     type_params:
-      numerator: recommended
+      numerator: recommended_count
       denominator: review_count

--- a/dbt/models/marts/metricflow_time_spine.sql
+++ b/dbt/models/marts/metricflow_time_spine.sql
@@ -1,0 +1,19 @@
+-- Daily calendar spine required by MetricFlow / dbt Semantic Layer.
+-- Range covers the Skytrax review window plus a short forward buffer.
+{{
+    config(
+        materialized='table',
+        tags=['marts', 'metricflow'],
+    )
+}}
+
+with days as (
+    {{ dbt_utils.date_spine(
+        datepart="day",
+        start_date="cast('2015-01-01' as date)",
+        end_date="cast('2030-01-01' as date)"
+    ) }}
+)
+
+select cast(date_day as date) as date_day
+from days

--- a/dbt/models/marts/metricflow_time_spine.yml
+++ b/dbt/models/marts/metricflow_time_spine.yml
@@ -1,0 +1,15 @@
+version: 2
+
+models:
+  - name: metricflow_time_spine
+    description: Daily time spine for MetricFlow metrics (one row per calendar day).
+    time_spine:
+      standard_granularity_column: date_day
+    columns:
+      - name: date_day
+        description: Calendar date at day grain.
+        granularity: day
+        data_type: date
+        tests:
+          - unique
+          - not_null


### PR DESCRIPTION
## Summary
- Wrap ratio inputs as simple metrics (`recommended_count` / `review_count`)
- Add `metricflow_time_spine` model + YAML so `dbt parse` succeeds

## Why
Merge-base CI on every PR currently fails parsing `main` after MetricFlow landed. Local `dbt parse` confirmed.

## Test plan
- [x] `dbt parse --target staging` succeeds locally

Made with [Cursor](https://cursor.com)