### PR TITLE
feat: clean airline names (strip review-count scrape junk)

### DIFF
--- a/dbt/macros/clean_airline_name.sql
+++ b/dbt/macros/clean_airline_name.sql
@@ -1,0 +1,26 @@
+{% macro clean_airline_name(column_name) %}
+{#-
+    Normalize airline names from the scrape:
+    - strip trailing review-count artifacts (e.g. "Frontier Airlines3843 Reviews")
+    - lowercase + trim
+    - coalesce null/empty to 'unknown'
+-#}
+coalesce(
+    nullif(
+        lower(
+            trim(
+                regexp_replace(
+                    coalesce({{ column_name }}, 'unknown'),
+                    '\\d*\\s*reviews?.*$',
+                    '',
+                    1,
+                    1,
+                    'i'
+                )
+            )
+        ),
+        ''
+    ),
+    'unknown'
+)
+{% endmacro %}

--- a/dbt/models/intermediate/_int_reviews__models.yml
+++ b/dbt/models/intermediate/_int_reviews__models.yml
@@ -27,7 +27,10 @@ models:
       - name: date_flown
         description: Date when the flight was taken.
       - name: airline_name
-        description: Name of the airline. Null values coalesced to 'Unknown'.
+        description: |
+          Airline name, lowercased and trimmed. Scraped review-count suffixes
+          (e.g. "Frontier Airlines3843 Reviews") are stripped before coalesce
+          to 'unknown' when null/empty.
         tests:
           - not_null
       - name: origin_city

--- a/dbt/models/intermediate/int_reviews_cleaned.sql
+++ b/dbt/models/intermediate/int_reviews_cleaned.sql
@@ -6,6 +6,7 @@
 -- Intermediate layer: clean and normalize staging data
 -- Grain: one row per review submission
 -- All business logic and nullability handling centralized here
+-- airline_name cleaned via clean_airline_name() macro
 
 with source_data as (
 
@@ -23,7 +24,7 @@ cleaned as (
         coalesce(nationality, 'unknown') as nationality,
         date_submitted,
         date_flown,
-        coalesce(airline_name, 'unknown') as airline_name,
+        {{ clean_airline_name('airline_name') }} as airline_name,
         coalesce(origin_city, 'unknown') as origin_city,
         coalesce(origin_airport, 'unknown') as origin_airport,
         coalesce(destination_city, 'unknown') as destination_city,


### PR DESCRIPTION
## Summary
- Add `clean_airline_name` macro to strip trailing review-count suffixes (e.g. `Frontier Airlines3843 Reviews`) and lowercase/trim airline names
- Apply the macro in `int_reviews_cleaned` so dims and `fct_review` inherit cleaned values

## Test plan
- [ ] `dbt compile -s int_reviews_cleaned`
- [ ] `dbt show -s int_reviews_cleaned --limit 20` and confirm no airline names contain `review`
- [ ] Rebuild `dim_airline` + full-refresh `fct_review` so existing dirty keys are rewritten
- [ ] Confirm previously split variants (dirty vs clean) collapse to one airline row


Made with [Cursor](https://cursor.com)