### PR TITLE
feat: daily LOAD_AUDIT tests and Airflow DAG

### DIFF
--- a/dbt-dags/dags/load_audit_dag.py
+++ b/dbt-dags/dags/load_audit_dag.py
@@ -1,0 +1,92 @@
+import os
+import subprocess
+import tempfile
+from datetime import datetime, timedelta
+
+from airflow.decorators import dag, task
+from airflow.hooks.base import BaseHook
+
+DBT_PROJECT_DIR = "/usr/local/airflow/dags/dbt"
+DBT_EXECUTABLE = f"{os.environ['AIRFLOW_HOME']}/dbt_venv/bin/dbt"
+
+# Source tests + singular tests tagged load_audit (see dbt/tests/assert_load_audit_*.sql
+# and models/staging/stg__skytrax_source.yml → LOAD_AUDIT).
+LOAD_AUDIT_SELECT = "tag:load_audit source:SKYTRAX_REVIEWS.LOAD_AUDIT"
+
+
+def _notify_failure(context):
+    """Log a clear failure line. Wire Slack/email here when a webhook is available."""
+    ti = context.get("task_instance") or context.get("ti")
+    dag_id = getattr(ti, "dag_id", "unknown_dag")
+    task_id = getattr(ti, "task_id", "unknown_task")
+    exception = context.get("exception")
+    print(f"[skytrax_load_audit] FAILED {dag_id}.{task_id}: {exception!r}")
+
+
+def _dbt_env() -> dict:
+    """Build env with Snowflake creds from the Airflow connection + writable scratch dirs."""
+    conn = BaseHook.get_connection("snowflake_default")
+    scratch = tempfile.mkdtemp(prefix="dbt_load_audit_")
+    return {
+        **os.environ,
+        "DBT_LOG_PATH": f"{scratch}/logs",
+        "DBT_TARGET_PATH": f"{scratch}/target",
+        "SNOWFLAKE_ACCOUNT": conn.extra_dejson["account"],
+        "SNOWFLAKE_USER": conn.login,
+        "SNOWFLAKE_PASSWORD": conn.password,
+        "SNOWFLAKE_ROLE": conn.extra_dejson.get("role", "SKYTRAX_TRANSFORMER"),
+        "SNOWFLAKE_SCHEMA": conn.schema or "SOURCE",
+    }
+
+
+def _run_dbt(args: list[str]) -> None:
+    cmd = [
+        DBT_EXECUTABLE,
+        *args,
+        "--project-dir",
+        DBT_PROJECT_DIR,
+        "--profiles-dir",
+        DBT_PROJECT_DIR,
+        "--target",
+        "prod",
+        "--quiet",
+    ]
+    print(f"Running: {' '.join(cmd)}")
+    result = subprocess.run(cmd, env=_dbt_env(), cwd=DBT_PROJECT_DIR)
+    if result.returncode != 0:
+        raise RuntimeError(f"dbt {' '.join(args)} exited with code {result.returncode}")
+
+
+@dag(
+    dag_id="skytrax_load_audit",
+    description=(
+        "Daily dbt checks on RAW.LOAD_AUDIT — freshness + reconciliation "
+        "(errors, row counts, recent activity)"
+    ),
+    schedule="0 14 * * *",  # 09:00 CDT / 14:00 UTC daily — after overnight EL
+    start_date=datetime(2025, 8, 1),
+    catchup=False,
+    tags=["dbt", "load_audit", "data_quality", "prod"],
+    default_args={
+        "depends_on_past": False,
+        "retries": 1,
+        "retry_delay": timedelta(minutes=5),
+        "on_failure_callback": _notify_failure,
+    },
+)
+def skytrax_load_audit():
+
+    @task
+    def source_freshness():
+        """Fail if LOAD_AUDIT.load_ts is stale (warn 3d / error 7d)."""
+        _run_dbt(["source", "freshness", "--select", "source:SKYTRAX_REVIEWS.LOAD_AUDIT"])
+
+    @task
+    def test_load_audit():
+        """Run LOAD_AUDIT schema tests + singular reconciliation tests."""
+        _run_dbt(["test", "--select", LOAD_AUDIT_SELECT])
+
+    source_freshness() >> test_load_audit()
+
+
+skytrax_load_audit()

--- a/dbt/models/staging/stg__skytrax_source.yml
+++ b/dbt/models/staging/stg__skytrax_source.yml
@@ -23,3 +23,77 @@ sources:
             warn_after: {count: 3, period: day}
             error_after: {count: 7, period: day}
           loaded_at_field: updated_at
+
+      - name: LOAD_AUDIT
+        description: |
+          Post-load reconciliation log written by the extract-load pipeline
+          after every COPY INTO (one row per file). Status/row counts come from
+          Snowflake's COPY result; SKIPPED means the file was already loaded.
+        config:
+          tags: ['load_audit']
+          # Same laptop-local EL cadence as AIRLINE_REVIEWS.
+          freshness:
+            warn_after: {count: 3, period: day}
+            error_after: {count: 7, period: day}
+          loaded_at_field: load_ts
+        columns:
+          - name: load_ts
+            description: Warehouse timestamp when the audit row was inserted.
+            data_tests:
+              - not_null:
+                  config:
+                    tags: ['load_audit']
+          - name: category
+            description: Review category loaded (airline, seat, lounge, airport).
+            data_tests:
+              - not_null:
+                  config:
+                    tags: ['load_audit']
+              - accepted_values:
+                  arguments:
+                    values: ['airline', 'seat', 'lounge', 'airport']
+                  config:
+                    tags: ['load_audit']
+          - name: s3_key
+            description: S3 object key (or prefix) that COPY INTO targeted.
+            data_tests:
+              - not_null:
+                  config:
+                    tags: ['load_audit']
+          - name: target_table
+            description: Fully qualified Snowflake table that received the load.
+            data_tests:
+              - not_null:
+                  config:
+                    tags: ['load_audit']
+          - name: status
+            description: |
+              COPY INTO file status (LOADED / PARTIALLY_LOADED / LOAD_FAILED)
+              or SKIPPED when the file was already loaded on a prior run.
+            data_tests:
+              - not_null:
+                  config:
+                    tags: ['load_audit']
+              - accepted_values:
+                  arguments:
+                    values: ['LOADED', 'PARTIALLY_LOADED', 'LOAD_FAILED', 'SKIPPED']
+                  config:
+                    tags: ['load_audit']
+          - name: rows_parsed
+            description: Rows Snowflake parsed from the file.
+            data_tests:
+              - not_null:
+                  config:
+                    tags: ['load_audit']
+          - name: rows_loaded
+            description: Rows successfully loaded into the target table.
+            data_tests:
+              - not_null:
+                  config:
+                    tags: ['load_audit']
+          - name: errors_seen
+            description: Rejected/error row count from COPY INTO.
+            data_tests:
+              - not_null:
+                  config:
+                    tags: ['load_audit']

--- a/dbt/tests/assert_load_audit_has_recent_activity.sql
+++ b/dbt/tests/assert_load_audit_has_recent_activity.sql
@@ -7,9 +7,10 @@
 -- Airflow instance, so short gaps are expected; this surfaces longer outages
 -- without paging. Pair with source freshness on load_ts for the hard error.
 
-select 1 as missing_recent_load
-where not exists (
-    select 1
+select 'missing_recent_load' as failure_reason,
+from (
+    select count(*) as recent_load_count,
     from {{ source('SKYTRAX_REVIEWS', 'LOAD_AUDIT') }}
     where load_ts >= dateadd('day', -3, current_timestamp())
-)
+) as recent
+where recent_load_count = 0

--- a/dbt/tests/assert_load_audit_has_recent_activity.sql
+++ b/dbt/tests/assert_load_audit_has_recent_activity.sql
@@ -1,0 +1,15 @@
+{{ config(
+    tags=['load_audit'],
+    severity='warn',
+) }}
+
+-- Warn when LOAD_AUDIT has had no rows for 3+ days. EL runs on a laptop-local
+-- Airflow instance, so short gaps are expected; this surfaces longer outages
+-- without paging. Pair with source freshness on load_ts for the hard error.
+
+select 1 as missing_recent_load
+where not exists (
+    select 1
+    from {{ source('SKYTRAX_REVIEWS', 'LOAD_AUDIT') }}
+    where load_ts >= dateadd('day', -3, current_timestamp())
+)

--- a/dbt/tests/assert_load_audit_no_recent_errors.sql
+++ b/dbt/tests/assert_load_audit_no_recent_errors.sql
@@ -1,0 +1,26 @@
+{{ config(
+    tags=['load_audit'],
+    severity='error',
+) }}
+
+-- Fail if any load in the last 7 days reported rejected rows or a failed /
+-- partial COPY INTO status. The EL task should already raise on this; this
+-- test is the warehouse-side backstop for silent under-loads.
+
+select
+    load_ts,
+    category,
+    review_date,
+    s3_key,
+    target_table,
+    status,
+    rows_parsed,
+    rows_loaded,
+    errors_seen,
+    first_error,
+from {{ source('SKYTRAX_REVIEWS', 'LOAD_AUDIT') }}
+where load_ts >= dateadd('day', -7, current_timestamp())
+    and (
+        coalesce(errors_seen, 0) > 0
+        or status in ('LOAD_FAILED', 'PARTIALLY_LOADED')
+    )

--- a/dbt/tests/assert_load_audit_rows_reconcile.sql
+++ b/dbt/tests/assert_load_audit_rows_reconcile.sql
@@ -1,0 +1,22 @@
+{{ config(
+    tags=['load_audit'],
+    severity='error',
+) }}
+
+-- Successful LOADED files must reconcile: every parsed row should land.
+-- SKIPPED re-runs are ignored (0/0 or informational COPY rows).
+
+select
+    load_ts,
+    category,
+    review_date,
+    s3_key,
+    target_table,
+    status,
+    rows_parsed,
+    rows_loaded,
+    errors_seen,
+from {{ source('SKYTRAX_REVIEWS', 'LOAD_AUDIT') }}
+where load_ts >= dateadd('day', -7, current_timestamp())
+    and status = 'LOADED'
+    and rows_parsed != rows_loaded


### PR DESCRIPTION
## Summary
- Declare `RAW.LOAD_AUDIT` as a dbt source with freshness on `load_ts` and schema tests (`not_null`, accepted `category`/`status`)
- Add singular reconciliation tests (`tag:load_audit`): recent errors/partial loads, LOADED row-count mismatches, and a warn-severity recent-activity check
- Add `skytrax_load_audit` Airflow DAG (daily 14:00 UTC) to run source freshness then `dbt test --select tag:load_audit source:SKYTRAX_REVIEWS.LOAD_AUDIT`

## Test plan
- [ ] `dbt parse` and `dbt ls --select tag:load_audit source:SKYTRAX_REVIEWS.LOAD_AUDIT --resource-type test` lists the new tests
- [ ] `dbt source freshness --select source:SKYTRAX_REVIEWS.LOAD_AUDIT`
- [ ] `dbt test --select tag:load_audit source:SKYTRAX_REVIEWS.LOAD_AUDIT`
- [ ] Deploy/restart Astro Airflow and confirm `skytrax_load_audit` appears and can be triggered manually
- [ ] Confirm TRANSFORMER can `SELECT` from `SKYTRAX_REVIEWS_DB.RAW.LOAD_AUDIT`


Made with [Cursor](https://cursor.com)