### PR TITLE
fix: improve dim_aircraft manufacturer and capacity matching

### DIFF
--- a/dbt/macros/aircraft.sql
+++ b/dbt/macros/aircraft.sql
@@ -1,0 +1,64 @@
+{% macro extract_aircraft_manufacturer(column_name) %}
+{#-
+    Derive manufacturer from the leading token of an aircraft model string.
+    e.g. "Boeing 737-800WINGLET" -> "Boeing", "unknown" -> "Unknown"
+-#}
+case
+    when lower(split_part({{ column_name }}, ' ', 1)) = 'unknown' then 'Unknown'
+    else split_part({{ column_name }}, ' ', 1)
+end
+{% endmacro %}
+
+
+{% macro aircraft_family_seed() %}
+{#-
+    Canonical aircraft family lookup used for fuzzy capacity matching.
+    Returns columns: model, manufacturer, capacity
+-#}
+{% set aircraft_data = [
+    {'model': 'A318', 'manufacturer': 'Airbus', 'capacity': 132},
+    {'model': 'A319', 'manufacturer': 'Airbus', 'capacity': 134},
+    {'model': 'A320', 'manufacturer': 'Airbus', 'capacity': 180},
+    {'model': 'A321', 'manufacturer': 'Airbus', 'capacity': 220},
+    {'model': 'A322', 'manufacturer': 'Airbus', 'capacity': 244},
+    {'model': 'A329', 'manufacturer': 'Airbus', 'capacity': 160},
+    {'model': 'A330', 'manufacturer': 'Airbus', 'capacity': 277},
+    {'model': 'A340', 'manufacturer': 'Airbus', 'capacity': 295},
+    {'model': 'A350', 'manufacturer': 'Airbus', 'capacity': 300},
+    {'model': 'A380', 'manufacturer': 'Airbus', 'capacity': 555},
+    {'model': 'Boeing 737', 'manufacturer': 'Boeing', 'capacity': 189},
+    {'model': 'Boeing 744', 'manufacturer': 'Boeing', 'capacity': 416},
+    {'model': 'Boeing 747', 'manufacturer': 'Boeing', 'capacity': 467},
+    {'model': 'Boeing 757', 'manufacturer': 'Boeing', 'capacity': 200},
+    {'model': 'Boeing 767', 'manufacturer': 'Boeing', 'capacity': 216},
+    {'model': 'Boeing 777', 'manufacturer': 'Boeing', 'capacity': 396},
+    {'model': 'Boeing 787', 'manufacturer': 'Boeing', 'capacity': 242},
+    {'model': 'Boeing 789', 'manufacturer': 'Boeing', 'capacity': 296},
+    {'model': 'Embraer 170', 'manufacturer': 'Embraer', 'capacity': 76},
+    {'model': 'Embraer 190', 'manufacturer': 'Embraer', 'capacity': 98},
+    {'model': 'Embraer 195', 'manufacturer': 'Embraer', 'capacity': 120},
+    {'model': 'Saab 2000', 'manufacturer': 'Saab', 'capacity': 50},
+    {'model': 'Unknown', 'manufacturer': 'Unknown', 'capacity': none},
+] %}
+select
+    *,
+from (
+    values
+    {% for aircraft in aircraft_data %}
+        (
+            '{{ aircraft.model }}',
+            '{{ aircraft.manufacturer }}',
+            {{ aircraft.capacity if aircraft.capacity is not none else 'null' }}
+        ){{ "," if not loop.last }}
+    {% endfor %}
+) as t (model, manufacturer, capacity)
+{% endmacro %}
+
+
+{% macro fuzzy_match_aircraft_family(model_column, seed_model_column) %}
+{#-
+    True when review model text contains a seed family name (case-insensitive).
+    Pair with QUALIFY ... order by length(seed_model) desc to prefer the longest hit.
+-#}
+contains(upper({{ model_column }}), upper({{ seed_model_column }}))
+{% endmacro %}

--- a/dbt/models/marts/dim_aircraft.sql
+++ b/dbt/models/marts/dim_aircraft.sql
@@ -70,11 +70,21 @@ final as (
     select
         {{ dbt_utils.generate_surrogate_key(['raw_aircraft.aircraft_model']) }} as aircraft_id,
         raw_aircraft.aircraft_model,
-        mapped.manufacturer as aircraft_manufacturer,
+        -- Manufacturer is the leading token in review text (e.g. "Boeing 737-800WINGLET").
+        case
+            when lower(split_part(raw_aircraft.aircraft_model, ' ', 1)) = 'unknown' then 'Unknown'
+            else split_part(raw_aircraft.aircraft_model, ' ', 1)
+        end as aircraft_manufacturer,
         mapped.capacity as seat_capacity,
     from raw_aircraft
     left join mapped
-        on raw_aircraft.aircraft_model = mapped.model
+        -- Fuzzy match for capacity only: variants (neo, winglets, suffixes) still map to a family.
+        -- Prefer the longest seed match when multiple families could apply.
+        on contains(upper(raw_aircraft.aircraft_model), upper(mapped.model))
+    qualify row_number() over (
+        partition by raw_aircraft.aircraft_model
+        order by length(mapped.model) desc nulls last
+    ) = 1
 
 )
 

--- a/dbt/models/marts/dim_aircraft.sql
+++ b/dbt/models/marts/dim_aircraft.sql
@@ -25,7 +25,6 @@ raw_aircraft as (
 mapped as (
 
     {{ aircraft_family_seed() }}
-
 ),
 
 final as (
@@ -39,9 +38,9 @@ final as (
     left join mapped
         on {{ fuzzy_match_aircraft_family('raw_aircraft.aircraft_model', 'mapped.model') }}
     qualify row_number() over (
-        partition by raw_aircraft.aircraft_model
-        order by length(mapped.model) desc nulls last
-    ) = 1
+            partition by raw_aircraft.aircraft_model
+            order by length(mapped.model) desc nulls last
+        ) = 1
 
 )
 

--- a/dbt/models/marts/dim_aircraft.sql
+++ b/dbt/models/marts/dim_aircraft.sql
@@ -7,32 +7,6 @@
 -- Grain: one row per unique aircraft model from reviews
 -- Surrogate key: generated using dbt_utils for deterministic, idempotent key generation
 
-{% set aircraft_data = [
-    {'model': 'A318', 'manufacturer': 'Airbus', 'capacity': 132},
-    {'model': 'A319', 'manufacturer': 'Airbus', 'capacity': 134},
-    {'model': 'A320', 'manufacturer': 'Airbus', 'capacity': 180},
-    {'model': 'A321', 'manufacturer': 'Airbus', 'capacity': 220},
-    {'model': 'A322', 'manufacturer': 'Airbus', 'capacity': 244},
-    {'model': 'A329', 'manufacturer': 'Airbus', 'capacity': 160},
-    {'model': 'A330', 'manufacturer': 'Airbus', 'capacity': 277},
-    {'model': 'A340', 'manufacturer': 'Airbus', 'capacity': 295},
-    {'model': 'A350', 'manufacturer': 'Airbus', 'capacity': 300},
-    {'model': 'A380', 'manufacturer': 'Airbus', 'capacity': 555},
-    {'model': 'Boeing 737', 'manufacturer': 'Boeing', 'capacity': 189},
-    {'model': 'Boeing 744', 'manufacturer': 'Boeing', 'capacity': 416},
-    {'model': 'Boeing 747', 'manufacturer': 'Boeing', 'capacity': 467},
-    {'model': 'Boeing 757', 'manufacturer': 'Boeing', 'capacity': 200},
-    {'model': 'Boeing 767', 'manufacturer': 'Boeing', 'capacity': 216},
-    {'model': 'Boeing 777', 'manufacturer': 'Boeing', 'capacity': 396},
-    {'model': 'Boeing 787', 'manufacturer': 'Boeing', 'capacity': 242},
-    {'model': 'Boeing 789', 'manufacturer': 'Boeing', 'capacity': 296},
-    {'model': 'Embraer 170', 'manufacturer': 'Embraer', 'capacity': 76},
-    {'model': 'Embraer 190', 'manufacturer': 'Embraer', 'capacity': 98},
-    {'model': 'Embraer 195', 'manufacturer': 'Embraer', 'capacity': 120},
-    {'model': 'Saab 2000', 'manufacturer': 'Saab', 'capacity': 50},
-    {'model': 'Unknown', 'manufacturer': 'Unknown', 'capacity': none},
-] %}
-
 with reviews as (
 
     select
@@ -50,18 +24,7 @@ raw_aircraft as (
 
 mapped as (
 
-    select
-        *,
-    from (
-        values
-        {% for aircraft in aircraft_data %}
-            (
-                '{{ aircraft.model }}',
-                '{{ aircraft.manufacturer }}',
-                {{ aircraft.capacity if aircraft.capacity is not none else 'null' }}
-            ){{ "," if not loop.last }}
-        {% endfor %}
-    ) as t (model, manufacturer, capacity)
+    {{ aircraft_family_seed() }}
 
 ),
 
@@ -70,17 +33,11 @@ final as (
     select
         {{ dbt_utils.generate_surrogate_key(['raw_aircraft.aircraft_model']) }} as aircraft_id,
         raw_aircraft.aircraft_model,
-        -- Manufacturer is the leading token in review text (e.g. "Boeing 737-800WINGLET").
-        case
-            when lower(split_part(raw_aircraft.aircraft_model, ' ', 1)) = 'unknown' then 'Unknown'
-            else split_part(raw_aircraft.aircraft_model, ' ', 1)
-        end as aircraft_manufacturer,
+        {{ extract_aircraft_manufacturer('raw_aircraft.aircraft_model') }} as aircraft_manufacturer,
         mapped.capacity as seat_capacity,
     from raw_aircraft
     left join mapped
-        -- Fuzzy match for capacity only: variants (neo, winglets, suffixes) still map to a family.
-        -- Prefer the longest seed match when multiple families could apply.
-        on contains(upper(raw_aircraft.aircraft_model), upper(mapped.model))
+        on {{ fuzzy_match_aircraft_family('raw_aircraft.aircraft_model', 'mapped.model') }}
     qualify row_number() over (
         partition by raw_aircraft.aircraft_model
         order by length(mapped.model) desc nulls last

--- a/dbt/models/marts/marts_schema.yml
+++ b/dbt/models/marts/marts_schema.yml
@@ -495,11 +495,11 @@ models:
 
       - name: aircraft_manufacturer
         data_type: varchar
-        description: Aircraft manufacturer (Airbus, Boeing, Embraer, Saab, Unknown).
+        description: Leading token of aircraft_model (e.g. Boeing, Airbus, Embraer, ATR, Saab, Unknown).
 
       - name: seat_capacity
         data_type: number
-        description: Maximum seating capacity of the aircraft.
+        description: Typical seating capacity from fuzzy family match; null when no seed family matches.
 
     config:
       contract:


### PR DESCRIPTION
## Summary
- Derive `aircraft_manufacturer` from the leading token of `aircraft_model` (e.g. `Boeing 737-800WINGLET` → Boeing) so manufacturer is populated for all real models.
- Fuzzy-match seat capacity against the seed family list with `contains()`, preferring the longest match for variants like neo/winglets/suffixes.
- Update column docs to reflect the new derivation rules.

## Test plan
- [x] `dbt run --select dim_aircraft` on dev
- [x] Confirm manufacturer non-null for all 229 rows; capacity populated for known family variants
- [ ] Spot-check Snowflake `dim_aircraft` for Boeing/Airbus/ATR/unknown rows
- [ ] CI green on this PR


Made with [Cursor](https://cursor.com)