### PR TITLE
refactor: drop redundant review_key, use review_id as fct_review PK

### DIFF
--- a/data_model/schema.txt
+++ b/data_model/schema.txt
@@ -1,6 +1,6 @@
 fct_review
 ----------
-review_key PK string
+review_id PK string
 customer_id string FK >- dim_customer.customer_id
 airline_id string FK >- dim_airline.airline_id
 date_submitted_id date FK >- dim_date.date_id
@@ -9,7 +9,6 @@ origin_location_id string FK >- dim_location.location_id
 destination_location_id string FK >- dim_location.location_id
 transit_location_id string FK >- dim_location.location_id
 aircraft_id string FK >- dim_aircraft.aircraft_id
-review_id string
 is_verified bool
 seat_type string
 type_of_traveller NULL string

--- a/dbt/README.md
+++ b/dbt/README.md
@@ -17,7 +17,7 @@ Three layers (see `../data_model/schema.png` for the ERD):
 
 Key design points:
 
-- **Incremental fact** — `fct_review` merges on `review_key` using the source
+- **Incremental fact** — `fct_review` merges on `review_id` using the source
   `updated_at` high-water mark with a lookback window
   (`--vars '{incremental_lookback_days: N}'`, default 3). Backfill with
   `dbt run -s fct_review --full-refresh`.

--- a/dbt/models/marts/fct_review.sql
+++ b/dbt/models/marts/fct_review.sql
@@ -1,6 +1,6 @@
 {{ config(
     materialized='incremental',
-    unique_key='review_key',
+    unique_key='review_id',
     incremental_strategy='merge',
     on_schema_change='fail',
 ) }}
@@ -8,9 +8,9 @@
 -- fct_review.sql
 -- Review fact table with enrichments (average ratings and rating bands)
 -- Grain: one row per review submission
--- Surrogate key: generated using dbt_utils for deterministic, idempotent key generation
+-- Primary key: review_id (deterministic natural-key hash from staging)
 -- All measures and dimensions are foreign keys to conformed dimensions
--- Incremental: merge on review_key; only rows with a source updated_at newer
+-- Incremental: merge on review_id; only rows with a source updated_at newer
 -- than the high-water mark are processed, minus a lookback window
 -- (var incremental_lookback_days, default 3) to absorb late-arriving updates.
 -- Backfill with: dbt run -s fct_review --full-refresh
@@ -131,7 +131,7 @@ with_ratings as (
 final as (
 
     select
-        {{ dbt_utils.generate_surrogate_key(['review_id', 'customer_name', 'date_submitted']) }} as review_key,
+        review_id,
         customer_id,
         airline_id,
         date_submitted_id,
@@ -140,7 +140,6 @@ final as (
         destination_location_id,
         transit_location_id,
         aircraft_id,
-        review_id,
         is_verified,
         seat_type,
         type_of_traveller,

--- a/dbt/models/marts/fct_review_semantic.yml
+++ b/dbt/models/marts/fct_review_semantic.yml
@@ -17,7 +17,7 @@ semantic_models:
     entities:
       - name: review
         type: primary
-        expr: review_key
+        expr: review_id
       - name: airline_entity
         type: foreign
         expr: airline_id

--- a/dbt/models/marts/marts_schema.yml
+++ b/dbt/models/marts/marts_schema.yml
@@ -7,23 +7,17 @@ models:
       Includes calculated average ratings and categorical rating bands.
       All foreign keys reference conformed dimensions.
       Grain: one row per review submission.
-      Materialized incrementally (merge on review_key) using the source
+      Materialized incrementally (merge on review_id) using the source
       updated_at high-water mark with a configurable lookback window.
     columns:
-      - name: review_key
-        data_type: varchar
-        description: Surrogate key for the review fact (deterministic, idempotent).
-        tests:
-          - unique
-          - not_null
-        config:
-          meta:
-            datatypes: string
-
       - name: review_id
         data_type: varchar
-        description: Review identifier — deterministic hash of the review natural key, assigned in staging.
+        description: |
+          Primary key — deterministic hash of the review natural key
+          (customer_name, nationality, airline_name, date_submitted, review),
+          assigned in staging.
         tests:
+          - unique
           - not_null
         config:
           meta:


### PR DESCRIPTION
## Summary
- Remove `review_key` from `fct_review` — it was a hash of `review_id` + columns already baked into `review_id`, so it added no uniqueness.
- Use staging's deterministic `review_id` as the fact primary key and incremental merge `unique_key`.
- Update schema YAML, semantic model entity, `schema.txt`, and dbt README accordingly.

## Deploy note
`on_schema_change='fail'` + dropped column + changed `unique_key` means prod needs:
```bash
dbt run -s fct_review --full-refresh
```

Also regenerate `data_model/schema.png` from the updated `schema.txt` via QuickDBD when convenient.

## Test plan
- [ ] `dbt compile -s fct_review`
- [ ] `dbt run -s fct_review --full-refresh` in a dev schema
- [ ] Confirm `unique` / `not_null` tests on `review_id` pass
- [ ] Confirm semantic model still parses (`dbt parse`)


Made with [Cursor](https://cursor.com)