### PR TITLE
ci: run PR models incremental then full-refresh

### DIFF
--- a/.github/workflows/pr_checks.yml
+++ b/.github/workflows/pr_checks.yml
@@ -280,8 +280,8 @@ jobs:
   # Job 4: Run changed models in the staging schema
   # ---------------------------------------------------------------------------
   # First clones production tables into staging (zero-copy), then runs only
-  # the changed models. This way, changed models can reference upstream
-  # parent tables that exist in staging via the clone.
+  # the changed models twice: incremental (MERGE into cloned prod shape), then
+  # --full-refresh (clean rebuild for tests / stale-clone safety).
   # ---------------------------------------------------------------------------
   run_changed:
     name: Run Changed Models
@@ -315,20 +315,38 @@ jobs:
             --state prod_state \
             --target staging
 
-      # Actually execute the changed models against Snowflake's staging schema.
+      # Incremental path: MERGE into the cloned prod tables. Catches schema/type
+      # drift, unique_key merge failures, and lookback bugs that --full-refresh
+      # would hide. New models with no cloned table create normally.
       # --fail-fast stops on the first failure instead of trying to run everything.
-      # --full-refresh: staging is cloned fresh from prod every run, so an
-      # incremental model here would try to MERGE into whatever schema/data
-      # prod happens to have (e.g. a stale column type from before a contract
-      # change), instead of building cleanly from the current model's logic.
-      - name: Run changed models
+      - name: Run changed models (incremental)
         working-directory: ./dbt
         run: |
           source ../dbt_venv/bin/activate
 
           MODELS="${{ needs.setup_env.outputs.changed_models }}"
           if [ -n "$MODELS" ]; then
-            echo "Running: $MODELS"
+            echo "Running (incremental): $MODELS"
+            dbt run \
+              --profiles-dir ./ \
+              --select $MODELS \
+              --target staging \
+              --fail-fast
+          else
+            echo "No changed models to run."
+          fi
+
+      # Full-refresh path: rebuild clean from current model SQL so tests see a
+      # fresh relation and downstream tables are not left as stale clones
+      # (e.g. after an upstream type/contract change).
+      - name: Run changed models (full-refresh)
+        working-directory: ./dbt
+        run: |
+          source ../dbt_venv/bin/activate
+
+          MODELS="${{ needs.setup_env.outputs.changed_models }}"
+          if [ -n "$MODELS" ]; then
+            echo "Running (full-refresh): $MODELS"
             dbt run \
               --profiles-dir ./ \
               --select $MODELS \

--- a/dbt/README.md
+++ b/dbt/README.md
@@ -57,8 +57,9 @@ Targets: `dev` (default), `staging` (CI), `prod` (deploy) — see `profiles.yml`
 ## CI/CD
 
 - `pr_checks.yml` — Slim CI: sqlfluff, compile, `dbt clone` prod → staging,
-  then build/test `state:modified+`/`state:new+` (the `+` matters — see below)
-  with `--full-refresh` in the staging build steps.
+  then build/test `state:modified+`/`state:new+` (the `+` matters — see below).
+  Staging runs changed models twice: incremental (MERGE into cloned prod),
+  then `--full-refresh` before tests.
 - `deploy_main.yml` — deploy on merge to `main` + weekly cron: `dbt build
   --select state:modified+ --defer --favor-state` against the prod manifest on
   S3, then publish dbt docs to CloudFront.

--- a/docs/cicd.md
+++ b/docs/cicd.md
@@ -178,11 +178,19 @@ dbt compile --select <changed_models> --target staging
 
 #### Job 4: Run Changed Models
 
-**Goal:** Actually execute the changed models against Snowflake.
+**Goal:** Actually execute the changed models against Snowflake — both
+materialization paths.
 
 ```bash
 dbt clone --state prod_state --target staging
 
+# 1) Incremental: MERGE into cloned prod tables (catch merge/schema drift)
+dbt run \
+  --select <changed_models> \
+  --target staging \
+  --fail-fast
+
+# 2) Full-refresh: clean rebuild before tests
 dbt run \
   --select <changed_models> \
   --target staging \
@@ -193,9 +201,10 @@ dbt run \
 - `dbt clone` first zero-copies the production tables into `STAGING`,
   so changed models can reference upstream parents that exist there
 - `--target staging` writes to the `STAGING` schema (CI scratch space)
-- `--full-refresh` rebuilds incremental models from scratch -- the clone
-  is recreated from prod every run, so merging into it would test against
-  whatever schema/data prod happens to have
+- Incremental run first probes the real MERGE path against prod-shaped
+  clones (schema/type drift, unique_key, lookback)
+- `--full-refresh` then rebuilds from scratch so tests see a clean
+  relation and stale clones are not left in place after upstream changes
 - `--fail-fast` stops on first failure to save time
 - Only runs if compilation succeeded (depends on Job 3)
 


### PR DESCRIPTION
## Summary
- After `dbt clone` in PR CI Job 4, run changed models without `--full-refresh` (MERGE into prod-shaped clones), then again with `--full-refresh` before tests
- Documents the dual-path staging build in `docs/cicd.md` and `dbt/README.md`
- Deploy workflow unchanged

## Test plan
- [ ] Open this PR and confirm Job 4 shows both steps: `Run changed models (incremental)` then `Run changed models (full-refresh)`
- [ ] Confirm incremental step fails on intentional merge/schema drift against cloned prod
- [ ] Confirm tests still run only after the full-refresh step
- [ ] Confirm unrelated PRs with only view/table (non-incremental) changes still pass both run steps


Made with [Cursor](https://cursor.com)