### PR TITLE
refactor: drop lookback from fct_review updated_at HWM

### DIFF
--- a/.github/workflows/pr_checks.yml
+++ b/.github/workflows/pr_checks.yml
@@ -316,7 +316,7 @@ jobs:
             --target staging
 
       # Incremental path: MERGE into the cloned prod tables. Catches schema/type
-      # drift, unique_key merge failures, and lookback bugs that --full-refresh
+      # drift, unique_key merge failures, and HWM filter bugs that --full-refresh
       # would hide. New models with no cloned table create normally.
       # --fail-fast stops on the first failure instead of trying to run everything.
       - name: Run changed models (incremental)

--- a/dbt/README.md
+++ b/dbt/README.md
@@ -17,9 +17,10 @@ Three layers (see `../data_model/schema.png` for the ERD):
 
 Key design points:
 
-- **Incremental fact** — `fct_review` merges on `review_id` using the source
-  `updated_at` high-water mark with a lookback window
-  (`--vars '{incremental_lookback_days: N}'`, default 3). Backfill with
+- **Incremental fact** — `fct_review` merges on `review_id` using a pure
+  `updated_at` high-water mark (no lookback; late/changed rows bump
+  `updated_at`). Lookback would only be needed for event-time filters
+  (e.g. `date_submitted`). Backfill with
   `dbt run -s fct_review --full-refresh`.
 - **Contract** — `fct_review` has an enforced dbt contract (column names + types).
 - **Governance** — `dim_customer.customer_name`/`nationality` get the

--- a/dbt/models/marts/fct_review.sql
+++ b/dbt/models/marts/fct_review.sql
@@ -25,7 +25,7 @@ with base as (
         -- instead, e.g. src.date_submitted, use a lookback window:
         --   where src.date_submitted > dateadd('day', -{{ var('incremental_lookback_days', 3) }}, max(...))
         where src.updated_at > (
-                select max(prev.source_updated_at)
+                select max(prev.source_updated_at) as max_source_updated_at,
                 from {{ this }} as prev
             )
     {% endif %}

--- a/dbt/models/marts/fct_review.sql
+++ b/dbt/models/marts/fct_review.sql
@@ -11,9 +11,9 @@
 -- Primary key: review_id (deterministic natural-key hash from staging)
 -- All measures and dimensions are foreign keys to conformed dimensions
 -- Incremental: merge on review_id; only rows with a source updated_at newer
--- than the high-water mark are processed, minus a lookback window
--- (var incremental_lookback_days, default 3) to absorb late-arriving updates.
--- Backfill with: dbt run -s fct_review --full-refresh
+-- than the high-water mark are processed. Pure HWM on updated_at — no lookback
+-- (late/changed rows bump updated_at). Lookback would be needed for event-time
+-- filters (e.g. date_submitted). Backfill with: dbt run -s fct_review --full-refresh
 
 with base as (
 
@@ -21,8 +21,11 @@ with base as (
         src.*,
     from {{ ref('int_reviews_cleaned') }} as src
     {% if is_incremental() %}
+        -- Pure HWM on updated_at (no lookback). If filtering on event time
+        -- instead, e.g. src.date_submitted, use a lookback window:
+        --   where src.date_submitted > dateadd('day', -{{ var('incremental_lookback_days', 3) }}, max(...))
         where src.updated_at > (
-                select dateadd('day', -{{ var('incremental_lookback_days', 3) }}, max(prev.source_updated_at))
+                select max(prev.source_updated_at)
                 from {{ this }} as prev
             )
     {% endif %}

--- a/dbt/models/marts/marts_schema.yml
+++ b/dbt/models/marts/marts_schema.yml
@@ -8,7 +8,7 @@ models:
       All foreign keys reference conformed dimensions.
       Grain: one row per review submission.
       Materialized incrementally (merge on review_id) using the source
-      updated_at high-water mark with a configurable lookback window.
+      updated_at high-water mark (no lookback — watermark moves with each change).
     columns:
       - name: review_id
         data_type: varchar

--- a/docs/cicd.md
+++ b/docs/cicd.md
@@ -202,7 +202,7 @@ dbt run \
   so changed models can reference upstream parents that exist there
 - `--target staging` writes to the `STAGING` schema (CI scratch space)
 - Incremental run first probes the real MERGE path against prod-shaped
-  clones (schema/type drift, unique_key, lookback)
+  clones (schema/type drift, unique_key, HWM filter)
 - `--full-refresh` then rebuilds from scratch so tests see a clean
   relation and stale clones are not left in place after upstream changes
 - `--fail-fast` stops on first failure to save time


### PR DESCRIPTION
## Description
Switch `fct_review` incremental filtering to a pure `updated_at` high-water mark. Lookback is unnecessary when the watermark column moves with each change; keep lookback only for event-time filters like `date_submitted`.

## Type of Change
- [x] Code refactoring
- [x] Documentation update
- [x] Performance improvement

## Changes Made
- Remove `incremental_lookback_days` from the `fct_review` incremental predicate (`updated_at > max(source_updated_at)`)
- Add a comment showing when lookback would still be needed (`date_submitted`)
- Update README, model docs, and CI wording to match

## Related Issues
N/A

## Testing
- [ ] dbt compile successful
- [ ] dbt run successful (`fct_review` incremental)
- [ ] dbt test successful
- [ ] Confirm an incremental run only pulls rows newer than the prior HWM

## Checklist
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings or errors
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes

## Additional Notes
Backfill / rebuild history still uses `dbt run -s fct_review --full-refresh`.

Made with [Cursor](https://cursor.com)